### PR TITLE
Add support for “Z” to represent UTC

### DIFF
--- a/fecha.js
+++ b/fecha.js
@@ -188,7 +188,8 @@
         d.isPm = true;
       }
     }],
-    ZZ: [/[\+\-]\d\d:?\d\d/, function (d, v) {
+    ZZ: [/([\+\-]\d\d:?\d\d|Z)/, function (d, v) {
+      if (v === 'Z') v = '+00:00';
       var parts = (v + '').match(/([\+\-]|\d\d)/gi), minutes;
 
       if (parts) {

--- a/test.js
+++ b/test.js
@@ -46,6 +46,7 @@ testParse('milliseconds medium', '10:20:30.12', 'HH:mm:ss.SS', new Date(year, 0,
 testParse('milliseconds short', '10:20:30.1', 'HH:mm:ss.S', new Date(year, 0, 1, 10, 20, 30, 100));
 testParse('timezone offset', '09:20:31 GMT-0500 (EST)', 'HH:mm:ss ZZ', new Date(Date.UTC(year, 0, 1, 14, 20, 31)));
 testParse('UTC timezone offset', '09:20:31 GMT-0000 (UTC)', 'HH:mm:ss ZZ', new Date(Date.UTC(year, 0, 1, 9, 20, 31)));
+testParse('UTC timezone offset without explicit offset', '09:20:31 Z', 'HH:mm:ss ZZ', new Date(Date.UTC(year, 0, 1, 9, 20, 31)));
 testParse('UTC timezone offset without GMT', '09:20:31 -0000 (UTC)', 'HH:mm:ss ZZ', new Date(Date.UTC(year, 0, 1, 9, 20, 31)));
 testParse('invalid date', 'hello', 'HH:mm:ss ZZ', false);
 test('i18n month short parse', function() {


### PR DESCRIPTION
According to the ISO 8601 standard, [`Z` can be used](https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators) to represent UTC time.

Without this pull request, `2017-04-11T14:00:00.000Z` gets parsed as `2017-04-11T14:00:00.000` in the local timezone. This pull request adds support for it (by treating it as `+00:00`) and correctly parses it as `2017-04-11T14:00:00.000Z`.